### PR TITLE
[fontconfig] Initial fontconfig configuration

### DIFF
--- a/fontconfig/C059.conf
+++ b/fontconfig/C059.conf
@@ -15,4 +15,23 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Century Schoolbook</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>New Century Schoolbook</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Tex Gyre Schola</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/C059.conf
+++ b/fontconfig/C059.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>C059</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>C059</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/C059.conf
+++ b/fontconfig/C059.conf
@@ -34,4 +34,17 @@
       <family>C059</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Century Schoolbook L</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Century SchoolBook URW</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/D050000L.conf
+++ b/fontconfig/D050000L.conf
@@ -34,4 +34,11 @@
       <family>D050000L</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Dingbats</family>
+    <accept>
+      <family>D050000L</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/D050000L.conf
+++ b/fontconfig/D050000L.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>fantasy</family>
+    <prefer>
+      <family>D050000L</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>D050000L</family>
+    <default>
+      <family>fantasy</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/D050000L.conf
+++ b/fontconfig/D050000L.conf
@@ -15,4 +15,23 @@
       <family>fantasy</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Zapf Dingbats</family>
+    <accept>
+      <family>D050000L</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>ITC Zapf Dingbats</family>
+    <accept>
+      <family>D050000L</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>ITC Zapf Dingbats Std</family>
+    <accept>
+      <family>D050000L</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusMonoPS.conf
+++ b/fontconfig/NimbusMonoPS.conf
@@ -15,4 +15,17 @@
       <family>monospace</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Courier</family>
+    <accept>
+      <family>Nimbus Mono PS</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Cursor</family>
+    <accept>
+      <family>Nimbus Mono PS</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusMonoPS.conf
+++ b/fontconfig/NimbusMonoPS.conf
@@ -28,4 +28,11 @@
       <family>Nimbus Mono PS</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Nimbus Mono L</family>
+    <accept>
+      <family>Nimbus Mono PS</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusMonoPS.conf
+++ b/fontconfig/NimbusMonoPS.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>monospace</family>
+    <prefer>
+      <family>Nimbus Mono PS</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>Nimbus Mono PS</family>
+    <default>
+      <family>monospace</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/NimbusRoman.conf
+++ b/fontconfig/NimbusRoman.conf
@@ -28,4 +28,11 @@
       <family>Nimbus Roman</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Nimbus Roman No9 L</family>
+    <accept>
+      <family>Nimbus Roman</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusRoman.conf
+++ b/fontconfig/NimbusRoman.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Nimbus Roman</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>Nimbus Roman</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/NimbusRoman.conf
+++ b/fontconfig/NimbusRoman.conf
@@ -15,4 +15,17 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Times</family>
+    <accept>
+      <family>Nimbus Roman</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Termes</family>
+    <accept>
+      <family>Nimbus Roman</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusSans.conf
+++ b/fontconfig/NimbusSans.conf
@@ -28,4 +28,11 @@
       <family>Nimbus Sans</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Nimbus Sans L</family>
+    <accept>
+      <family>Nimbus Sans</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusSans.conf
+++ b/fontconfig/NimbusSans.conf
@@ -15,4 +15,17 @@
       <family>sans-serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Helvetica</family>
+    <accept>
+      <family>Nimbus Sans</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Heroes</family>
+    <accept>
+      <family>Nimbus Sans</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusSans.conf
+++ b/fontconfig/NimbusSans.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Nimbus Sans</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>Nimbus Sans</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/NimbusSansNarrow.conf
+++ b/fontconfig/NimbusSansNarrow.conf
@@ -28,4 +28,6 @@
       <family>Nimbus Sans Narrow</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <!-- NOTE: Currently there are no previous version for Nimbus Sans Narrow -->
 </fontconfig>

--- a/fontconfig/NimbusSansNarrow.conf
+++ b/fontconfig/NimbusSansNarrow.conf
@@ -15,4 +15,17 @@
       <family>sans-serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Helvetica Condensed</family>
+    <accept>
+      <family>Nimbus Sans Narrow</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Heroes Cn</family>
+    <accept>
+      <family>Nimbus Sans Narrow</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/NimbusSansNarrow.conf
+++ b/fontconfig/NimbusSansNarrow.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Nimbus Sans Narrow</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>Nimbus Sans Narrow</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/P052.conf
+++ b/fontconfig/P052.conf
@@ -34,4 +34,17 @@
       <family>P052</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Palladio URW</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>URW Palladio L</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/P052.conf
+++ b/fontconfig/P052.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>P052</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>P052</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/P052.conf
+++ b/fontconfig/P052.conf
@@ -15,4 +15,23 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Palatino</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Tex Gyre Pagella</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Palatino Linotype</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/StandardSymbolsPS.conf
+++ b/fontconfig/StandardSymbolsPS.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Standard Symbols PS</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>Standard Symbols PS</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/StandardSymbolsPS.conf
+++ b/fontconfig/StandardSymbolsPS.conf
@@ -15,4 +15,17 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>Symbol</family>
+    <accept>
+      <family>Standard Symbols PS</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>SymbolNeu</family>
+    <accept>
+      <family>Standard Symbols PS</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/StandardSymbolsPS.conf
+++ b/fontconfig/StandardSymbolsPS.conf
@@ -28,4 +28,11 @@
       <family>Standard Symbols PS</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Standard Symbols L</family>
+    <accept>
+      <family>Standard Symbols PS</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/URWBookman.conf
+++ b/fontconfig/URWBookman.conf
@@ -15,4 +15,23 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>ITC Bookman</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Bonum</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Bookman Old Style</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/URWBookman.conf
+++ b/fontconfig/URWBookman.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>URW Bookman</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>URW Bookman</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/URWBookman.conf
+++ b/fontconfig/URWBookman.conf
@@ -34,4 +34,17 @@
       <family>URW Bookman</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Bookman URW</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>URW Bookman L</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/URWGothic.conf
+++ b/fontconfig/URWGothic.conf
@@ -15,4 +15,17 @@
       <family>sans-serif</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>ITC Avant Garde Gothic</family>
+    <accept>
+      <family>URW Gothic</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Adventor</family>
+    <accept>
+      <family>URW Gothic</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/URWGothic.conf
+++ b/fontconfig/URWGothic.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>URW Gothic</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>URW Gothic</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/URWGothic.conf
+++ b/fontconfig/URWGothic.conf
@@ -28,4 +28,11 @@
       <family>URW Gothic</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>URW Gothic L</family>
+    <accept>
+      <family>URW Gothic</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/Z003.conf
+++ b/fontconfig/Z003.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Generic name aliasing -->
+  <alias>
+    <family>cursive</family>
+    <prefer>
+      <family>Z003</family>
+    </prefer>
+  </alias>
+  <!-- Generic name assignment -->
+  <alias>
+    <family>Z003</family>
+    <default>
+      <family>cursive</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/fontconfig/Z003.conf
+++ b/fontconfig/Z003.conf
@@ -28,4 +28,17 @@
       <family>Z003</family>
     </accept>
   </alias>
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Chancery URW</family>
+    <accept>
+      <family>Z003</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>URW Chancery L</family>
+    <accept>
+      <family>Z003</family>
+    </accept>
+  </alias>
 </fontconfig>

--- a/fontconfig/Z003.conf
+++ b/fontconfig/Z003.conf
@@ -15,4 +15,17 @@
       <family>cursive</family>
     </default>
   </alias>
+  <!-- Font substitution rules -->
+  <alias binding="same">
+    <family>ITC Zapf Chancery</family>
+    <accept>
+      <family>Z003</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>TeX Gyre Chorus</family>
+    <accept>
+      <family>Z003</family>
+    </accept>
+  </alias>
 </fontconfig>


### PR DESCRIPTION
This is the initial [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) configuration for the Level 2 Core Font Set by (URW)++.

Once we have these files in the next `urw-base35-fonts` release, I will inform fontconfig upstream for them to adjust their files & configuration accordingly.