### PR TITLE
[fontconfig] Sync with fontconfig upstream

### DIFF
--- a/fontconfig/README
+++ b/fontconfig/README
@@ -1,0 +1,28 @@
+# fontconfig files for (URW)++ Core Font Set [Level 2]
+
+These files contains the necessary configuration files for use with fontconfig:
+>> https://www.freedesktop.org/wiki/Software/fontconfig/
+
+Previously, this configuration was part of the fontconfig project itself, but
+fontconfig upstream and Artifex company agreed to keep these configuration files
+together with the font files themselves.
+
+In case you see some bug/error in these configuration files, feel free to report
+and issue, or (better) create a new pull-request on github.com:
+>> https://github.com/ArtifexSoftware/urw-base35-fonts
+
+# IMPORTANT NOTE
+Previously, this configuration for these font had priority/ordering value of 30.
+(The configuration was part of 30-metric-aliases.conf and 30-urw-aliases.conf in
+ fontconfif upstream's default configuration files.)
+
+Currently these files no longer contain the priority/ordering value as part of
+their name. It is preferred that each distribution using fontconfig decides on
+the priority/ordering value by themselves, depending on theirs internal politics,
+processes, preferences, etc., and rename those files appropriately.
+
+For more info on the priority of fontconfig configuration files, visit e.g.:
+>> https://fedoraproject.org/wiki/Fontconfig_packaging_tips
+
+In case you are still not sure what priority/ordering value you should use, you
+could stick up with the previously used (default) value of 30.

--- a/fontconfig/c059.conf
+++ b/fontconfig/c059.conf
@@ -8,6 +8,7 @@
       <family>C059</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>C059</family>
@@ -15,6 +16,7 @@
       <family>serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>C059</family>
@@ -22,25 +24,29 @@
       <family>New Century Schoolbook</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
-  <alias binding="same">
-    <family>Century Schoolbook</family>
-    <accept>
-      <family>C059</family>
-    </accept>
-  </alias>
   <alias binding="same">
     <family>New Century Schoolbook</family>
     <accept>
       <family>C059</family>
     </accept>
   </alias>
+
+  <alias binding="same">
+    <family>Century Schoolbook</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+
   <alias binding="same">
     <family>Tex Gyre Schola</family>
     <accept>
       <family>C059</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Century Schoolbook L</family>
@@ -48,6 +54,7 @@
       <family>C059</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>Century SchoolBook URW</family>
     <accept>

--- a/fontconfig/c059.conf
+++ b/fontconfig/c059.conf
@@ -15,6 +15,13 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>C059</family>
+    <default>
+      <family>New Century Schoolbook</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Century Schoolbook</family>

--- a/fontconfig/c059.conf
+++ b/fontconfig/c059.conf
@@ -46,19 +46,4 @@
       <family>C059</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Century Schoolbook L</family>
-    <accept>
-      <family>C059</family>
-    </accept>
-  </alias>
-
-  <alias binding="same">
-    <family>Century SchoolBook URW</family>
-    <accept>
-      <family>C059</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/d050000l.conf
+++ b/fontconfig/d050000l.conf
@@ -46,12 +46,4 @@
       <family>D050000L</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Dingbats</family>
-    <accept>
-      <family>D050000L</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/d050000l.conf
+++ b/fontconfig/d050000l.conf
@@ -15,6 +15,13 @@
       <family>fantasy</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>D050000L</family>
+    <default>
+      <family>ITC Zapf Dingbats</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Zapf Dingbats</family>

--- a/fontconfig/d050000l.conf
+++ b/fontconfig/d050000l.conf
@@ -8,6 +8,7 @@
       <family>D050000L</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>D050000L</family>
@@ -15,6 +16,7 @@
       <family>fantasy</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>D050000L</family>
@@ -22,25 +24,29 @@
       <family>ITC Zapf Dingbats</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
-  <alias binding="same">
-    <family>Zapf Dingbats</family>
-    <accept>
-      <family>D050000L</family>
-    </accept>
-  </alias>
   <alias binding="same">
     <family>ITC Zapf Dingbats</family>
     <accept>
       <family>D050000L</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>ITC Zapf Dingbats Std</family>
     <accept>
       <family>D050000L</family>
     </accept>
   </alias>
+
+  <alias binding="same">
+    <family>Zapf Dingbats</family>
+    <accept>
+      <family>D050000L</family>
+    </accept>
+  </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Dingbats</family>

--- a/fontconfig/nimbus-mono-ps.conf
+++ b/fontconfig/nimbus-mono-ps.conf
@@ -15,6 +15,13 @@
       <family>monospace</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Nimbus Mono PS</family>
+    <default>
+      <family>Courier</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Courier</family>

--- a/fontconfig/nimbus-mono-ps.conf
+++ b/fontconfig/nimbus-mono-ps.conf
@@ -8,6 +8,7 @@
       <family>Nimbus Mono PS</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>Nimbus Mono PS</family>
@@ -15,6 +16,7 @@
       <family>monospace</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Nimbus Mono PS</family>
@@ -22,6 +24,7 @@
       <family>Courier</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Courier</family>
@@ -29,12 +32,14 @@
       <family>Nimbus Mono PS</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>TeX Gyre Cursor</family>
     <accept>
       <family>Nimbus Mono PS</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Nimbus Mono L</family>

--- a/fontconfig/nimbus-mono-ps.conf
+++ b/fontconfig/nimbus-mono-ps.conf
@@ -39,12 +39,4 @@
       <family>Nimbus Mono PS</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Nimbus Mono L</family>
-    <accept>
-      <family>Nimbus Mono PS</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/nimbus-roman.conf
+++ b/fontconfig/nimbus-roman.conf
@@ -39,12 +39,4 @@
       <family>Nimbus Roman</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Nimbus Roman No9 L</family>
-    <accept>
-      <family>Nimbus Roman</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/nimbus-roman.conf
+++ b/fontconfig/nimbus-roman.conf
@@ -15,6 +15,13 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Nimbus Roman</family>
+    <default>
+      <family>Times</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Times</family>

--- a/fontconfig/nimbus-roman.conf
+++ b/fontconfig/nimbus-roman.conf
@@ -8,6 +8,7 @@
       <family>Nimbus Roman</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>Nimbus Roman</family>
@@ -15,6 +16,7 @@
       <family>serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Nimbus Roman</family>
@@ -22,6 +24,7 @@
       <family>Times</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Times</family>
@@ -29,12 +32,14 @@
       <family>Nimbus Roman</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>TeX Gyre Termes</family>
     <accept>
       <family>Nimbus Roman</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Nimbus Roman No9 L</family>

--- a/fontconfig/nimbus-sans-narrow.conf
+++ b/fontconfig/nimbus-sans-narrow.conf
@@ -39,7 +39,4 @@
       <family>Nimbus Sans Narrow</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <!-- NOTE: Currently there are no previous version for Nimbus Sans Narrow -->
 </fontconfig>

--- a/fontconfig/nimbus-sans-narrow.conf
+++ b/fontconfig/nimbus-sans-narrow.conf
@@ -17,7 +17,7 @@
   </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
-    <family>Helvetica Condensed</family>
+    <family>Helvetica Narrow</family>
     <accept>
       <family>Nimbus Sans Narrow</family>
     </accept>

--- a/fontconfig/nimbus-sans-narrow.conf
+++ b/fontconfig/nimbus-sans-narrow.conf
@@ -8,6 +8,7 @@
       <family>Nimbus Sans Narrow</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>Nimbus Sans Narrow</family>
@@ -15,6 +16,7 @@
       <family>sans-serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Nimbus Sans Narrow</family>
@@ -22,6 +24,7 @@
       <family>Helvetica Narrow</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Helvetica Narrow</family>
@@ -29,12 +32,14 @@
       <family>Nimbus Sans Narrow</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>TeX Gyre Heroes Cn</family>
     <accept>
       <family>Nimbus Sans Narrow</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <!-- NOTE: Currently there are no previous version for Nimbus Sans Narrow -->
 </fontconfig>

--- a/fontconfig/nimbus-sans-narrow.conf
+++ b/fontconfig/nimbus-sans-narrow.conf
@@ -15,6 +15,13 @@
       <family>sans-serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Nimbus Sans Narrow</family>
+    <default>
+      <family>Helvetica Narrow</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Helvetica Narrow</family>

--- a/fontconfig/nimbus-sans.conf
+++ b/fontconfig/nimbus-sans.conf
@@ -39,12 +39,4 @@
       <family>Nimbus Sans</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Nimbus Sans L</family>
-    <accept>
-      <family>Nimbus Sans</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/nimbus-sans.conf
+++ b/fontconfig/nimbus-sans.conf
@@ -8,6 +8,7 @@
       <family>Nimbus Sans</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>Nimbus Sans</family>
@@ -15,6 +16,7 @@
       <family>sans-serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Nimbus Sans</family>
@@ -22,6 +24,7 @@
       <family>Helvetica</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Helvetica</family>
@@ -29,12 +32,14 @@
       <family>Nimbus Sans</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>TeX Gyre Heroes</family>
     <accept>
       <family>Nimbus Sans</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Nimbus Sans L</family>

--- a/fontconfig/nimbus-sans.conf
+++ b/fontconfig/nimbus-sans.conf
@@ -15,6 +15,13 @@
       <family>sans-serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Nimbus Sans</family>
+    <default>
+      <family>Helvetica</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Helvetica</family>

--- a/fontconfig/p052.conf
+++ b/fontconfig/p052.conf
@@ -8,6 +8,7 @@
       <family>P052</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>P052</family>
@@ -15,6 +16,7 @@
       <family>serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>P052</family>
@@ -22,6 +24,7 @@
       <family>Palatino</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Palatino</family>
@@ -29,18 +32,21 @@
       <family>P052</family>
     </accept>
   </alias>
-  <alias binding="same">
-    <family>Tex Gyre Pagella</family>
-    <accept>
-      <family>P052</family>
-    </accept>
-  </alias>
+
   <alias binding="same">
     <family>Palatino Linotype</family>
     <accept>
       <family>P052</family>
     </accept>
   </alias>
+
+  <alias binding="same">
+    <family>Tex Gyre Pagella</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Palladio URW</family>
@@ -48,6 +54,7 @@
       <family>P052</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>URW Palladio L</family>
     <accept>

--- a/fontconfig/p052.conf
+++ b/fontconfig/p052.conf
@@ -46,19 +46,4 @@
       <family>P052</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Palladio URW</family>
-    <accept>
-      <family>P052</family>
-    </accept>
-  </alias>
-
-  <alias binding="same">
-    <family>URW Palladio L</family>
-    <accept>
-      <family>P052</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/p052.conf
+++ b/fontconfig/p052.conf
@@ -15,6 +15,13 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>P052</family>
+    <default>
+      <family>Palatino</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Palatino</family>

--- a/fontconfig/standard-symbols-ps.conf
+++ b/fontconfig/standard-symbols-ps.conf
@@ -46,12 +46,4 @@
       <family>Standard Symbols PS</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Standard Symbols L</family>
-    <accept>
-      <family>Standard Symbols PS</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/standard-symbols-ps.conf
+++ b/fontconfig/standard-symbols-ps.conf
@@ -8,6 +8,7 @@
       <family>Standard Symbols PS</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>Standard Symbols PS</family>
@@ -15,6 +16,7 @@
       <family>serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Standard Symbols PS</family>
@@ -22,6 +24,7 @@
       <family>Symbol</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Symbol</family>
@@ -29,18 +32,21 @@
       <family>Standard Symbols PS</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>SymbolNeu</family>
     <accept>
       <family>Standard Symbols PS</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>Symbol Neu for Powerline</family>
     <accept>
       <family>Standard Symbols PS</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Standard Symbols L</family>

--- a/fontconfig/standard-symbols-ps.conf
+++ b/fontconfig/standard-symbols-ps.conf
@@ -28,6 +28,12 @@
       <family>Standard Symbols PS</family>
     </accept>
   </alias>
+  <alias binding="same">
+    <family>Symbol Neu for Powerline</family>
+    <accept>
+      <family>Standard Symbols PS</family>
+    </accept>
+  </alias>
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Standard Symbols L</family>

--- a/fontconfig/standard-symbols-ps.conf
+++ b/fontconfig/standard-symbols-ps.conf
@@ -15,6 +15,13 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Standard Symbols PS</family>
+    <default>
+      <family>Symbol</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>Symbol</family>

--- a/fontconfig/urw-bookman.conf
+++ b/fontconfig/urw-bookman.conf
@@ -8,6 +8,7 @@
       <family>URW Bookman</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>URW Bookman</family>
@@ -15,6 +16,7 @@
       <family>serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>URW Bookman</family>
@@ -22,6 +24,7 @@
       <family>ITC Bookman</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>ITC Bookman</family>
@@ -29,18 +32,21 @@
       <family>URW Bookman</family>
     </accept>
   </alias>
-  <alias binding="same">
-    <family>TeX Gyre Bonum</family>
-    <accept>
-      <family>URW Bookman</family>
-    </accept>
-  </alias>
+
   <alias binding="same">
     <family>Bookman Old Style</family>
     <accept>
       <family>URW Bookman</family>
     </accept>
   </alias>
+
+  <alias binding="same">
+    <family>TeX Gyre Bonum</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Bookman URW</family>
@@ -48,6 +54,7 @@
       <family>URW Bookman</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>URW Bookman L</family>
     <accept>

--- a/fontconfig/urw-bookman.conf
+++ b/fontconfig/urw-bookman.conf
@@ -15,6 +15,13 @@
       <family>serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>URW Bookman</family>
+    <default>
+      <family>ITC Bookman</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>ITC Bookman</family>

--- a/fontconfig/urw-bookman.conf
+++ b/fontconfig/urw-bookman.conf
@@ -46,19 +46,4 @@
       <family>URW Bookman</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Bookman URW</family>
-    <accept>
-      <family>URW Bookman</family>
-    </accept>
-  </alias>
-
-  <alias binding="same">
-    <family>URW Bookman L</family>
-    <accept>
-      <family>URW Bookman</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/urw-fallback.conf
+++ b/fontconfig/urw-fallback.conf
@@ -1,6 +1,5 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<fontconfig>
 
 <!--
 This file is used to alias/map previous versions of font families from (URW)++
@@ -40,7 +39,8 @@ but in an order preferring similar designs first. We do this in three steps:
    e.g. Nimbus Mono to Nimbus Mono PS
 -->
 
-<!-- Original PostScript base font mapping -->
+<fontconfig>
+  <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Nimbus Mono</family>
     <default>
@@ -219,6 +219,114 @@ but in an order preferring similar designs first. We do this in three steps:
     <family>Times</family>
     <accept>
       <family>Nimbus Roman No9 L</family>
+    </accept>
+  </alias>
+
+  <!-- Substitutions for backward compatibility with previous versions -->
+  <alias binding="same">
+    <family>Century Schoolbook L</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Century SchoolBook URW</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Dingbats</family>
+    <accept>
+      <family>D050000L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Mono</family>
+    <accept>
+      <family>Nimbus Mono PS</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Mono L</family>
+    <accept>
+      <family>Nimbus Mono PS</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Roman No9 L</family>
+    <accept>
+      <family>Nimbus Roman</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Sans L</family>
+    <accept>
+      <family>Nimbus Sans</family>
+    </accept>
+  </alias>
+
+  <!-- NOTE: Currently there are no previous versions for Nimbus Sans Narrow -->
+
+  <alias binding="same">
+    <family>Palladio URW</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Palladio L</family>
+    <accept>
+      <family>P052</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Standard Symbols L</family>
+    <accept>
+      <family>Standard Symbols PS</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Bookman URW</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Bookman L</family>
+    <accept>
+      <family>URW Bookman</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Gothic L</family>
+    <accept>
+      <family>URW Gothic</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Chancery URW</family>
+    <accept>
+      <family>Z003</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Chancery L</family>
+    <accept>
+      <family>Z003</family>
     </accept>
   </alias>
 </fontconfig>

--- a/fontconfig/urw-fallback.conf
+++ b/fontconfig/urw-fallback.conf
@@ -1,0 +1,224 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+
+<!--
+This file is used to alias/map previous versions of font families from (URW)++
+to similar/metric-compatible font families - either original PostScript fonts
+(as generics), or newer font versions from (URW)++ itself.
+
+Most likely this aliasing/mapping will be useful for people who:
+ * have latest versions of (URW)++ fonts, but their documents still reference
+   or requires older versions of these fonts
+ * have original PostScript fons installed, but their documents require some
+   older versions of (URW)++ fonts
+
+PostScript fonts:       latest URW fonts:     previous URW fonts:
+======================  ====================  =============================================
+Courier                 Nimbus Mono PS        Nimbus Mono L | Nimbus Mono
+ITC Avant Garde Gothic  URW Gothic            URW Gothic L
+ITC Bookman             URW Bookman           URW Bookman L | Bookman URW
+ITC Zapf Chancery       Z003                  URW Chancery L | Chancery URW
+ITC Zapf Dingbats       D050000L              Dingbats
+Helvetica               Nimbus Sans           Nimbus Sans L
+Helvetica Narrow        Nimbus Sans Narrow    Nimbus Sans Narrow (same as current name)
+New Century Schoolbook  C059                  Century Schoolbook L | Century SchoolBook URW
+Palatino                P052                  URW Palladio L | Palladio URW
+Symbol                  Standard Symbols PS   Standard Symbols L
+Times                   Nimbus Roman          Nimbus Roman No9 L
+
+We want for each of them to fallback to any of these available,
+but in an order preferring similar designs first. We do this in three steps:
+
+1) Map each specific font to original PostScript font family,
+   e.g. Nimbus Mono to Courier
+
+2) Map each original PostScript family to its specific font,
+   e.g. Courier to Nimbus Mono
+
+3) Alias all previous names of URW fonts to the latest released version,
+   e.g. Nimbus Mono to Nimbus Mono PS
+-->
+
+<!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Nimbus Mono</family>
+    <default>
+      <family>Courier</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Mono L</family>
+    <default>
+      <family>Courier</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Sans L</family>
+    <default>
+      <family>Helvetica</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Gothic L</family>
+    <default>
+      <family>ITC Avant Garde Gothic</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Bookman URW</family>
+    <default>
+      <family>ITC Bookman</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Bookman L</family>
+    <default>
+      <family>ITC Bookman</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Chancery URW</family>
+    <default>
+      <family>ITC Zapf Chancery</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Chancery L</family>
+    <default>
+      <family>ITC Zapf Chancery</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Dingbats</family>
+    <default>
+      <family>ITC Zapf Dingbats</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Century Schoolbook L</family>
+    <default>
+      <family>New Century Schoolbook</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Century SchoolBook URW</family>
+    <default>
+      <family>New Century Schoolbook</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Palladio URW</family>
+    <default>
+      <family>Palatino</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>URW Palladio L</family>
+    <default>
+      <family>Palatino</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Standard Symbols L</family>
+    <default>
+      <family>Symbol</family>
+    </default>
+  </alias>
+
+  <alias binding="same">
+    <family>Nimbus Roman No9 L</family>
+    <default>
+      <family>Times</family>
+    </default>
+  </alias>
+
+  <!-- Map generics to specifics -->
+  <alias binding="same">
+    <family>Courier</family>
+    <accept>
+      <family>Nimbus Mono</family>
+      <family>Nimbus Mono L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Helvetica</family>
+    <accept>
+      <family>Nimbus Sans L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>ITC Avant Garde Gothic</family>
+    <accept>
+      <family>URW Gothic L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>ITC Bookman</family>
+    <accept>
+      <family>Bookman URW</family>
+      <family>URW Bookman L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>ITC Zapf Chancery</family>
+    <accept>
+      <family>Chancery URW</family>
+      <family>URW Chancery L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>ITC Zapf Dingbats</family>
+    <accept>
+      <family>Dingbats</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>New Century Schoolbook</family>
+    <accept>
+      <family>Century Schoolbook L</family>
+      <family>Century SchoolBook URW</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Palatino</family>
+    <accept>
+      <family>Palladio URW</family>
+      <family>URW Palladio L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Symbol</family>
+    <accept>
+      <family>Standard Symbols L</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
+    <family>Times</family>
+    <accept>
+      <family>Nimbus Roman No9 L</family>
+    </accept>
+  </alias>
+</fontconfig>

--- a/fontconfig/urw-gothic.conf
+++ b/fontconfig/urw-gothic.conf
@@ -15,6 +15,13 @@
       <family>sans-serif</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>URW Gothic</family>
+    <default>
+      <family>ITC Avant Garde Gothic</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>ITC Avant Garde Gothic</family>

--- a/fontconfig/urw-gothic.conf
+++ b/fontconfig/urw-gothic.conf
@@ -39,12 +39,4 @@
       <family>URW Gothic</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>URW Gothic L</family>
-    <accept>
-      <family>URW Gothic</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/urw-gothic.conf
+++ b/fontconfig/urw-gothic.conf
@@ -8,6 +8,7 @@
       <family>URW Gothic</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>URW Gothic</family>
@@ -15,6 +16,7 @@
       <family>sans-serif</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>URW Gothic</family>
@@ -22,6 +24,7 @@
       <family>ITC Avant Garde Gothic</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>ITC Avant Garde Gothic</family>
@@ -29,12 +32,14 @@
       <family>URW Gothic</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>TeX Gyre Adventor</family>
     <accept>
       <family>URW Gothic</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>URW Gothic L</family>

--- a/fontconfig/z003.conf
+++ b/fontconfig/z003.conf
@@ -39,19 +39,4 @@
       <family>Z003</family>
     </accept>
   </alias>
-
-  <!-- Substitutions for backward compatibility with previous versions -->
-  <alias binding="same">
-    <family>Chancery URW</family>
-    <accept>
-      <family>Z003</family>
-    </accept>
-  </alias>
-
-  <alias binding="same">
-    <family>URW Chancery L</family>
-    <accept>
-      <family>Z003</family>
-    </accept>
-  </alias>
 </fontconfig>

--- a/fontconfig/z003.conf
+++ b/fontconfig/z003.conf
@@ -8,6 +8,7 @@
       <family>Z003</family>
     </prefer>
   </alias>
+
   <!-- Generic name assignment -->
   <alias>
     <family>Z003</family>
@@ -15,6 +16,7 @@
       <family>cursive</family>
     </default>
   </alias>
+
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>Z003</family>
@@ -22,6 +24,7 @@
       <family>ITC Zapf Chancery</family>
     </default>
   </alias>
+
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>ITC Zapf Chancery</family>
@@ -29,12 +32,14 @@
       <family>Z003</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>TeX Gyre Chorus</family>
     <accept>
       <family>Z003</family>
     </accept>
   </alias>
+
   <!-- Substitutions for backward compatibility with previous versions -->
   <alias binding="same">
     <family>Chancery URW</family>
@@ -42,6 +47,7 @@
       <family>Z003</family>
     </accept>
   </alias>
+
   <alias binding="same">
     <family>URW Chancery L</family>
     <accept>

--- a/fontconfig/z003.conf
+++ b/fontconfig/z003.conf
@@ -15,6 +15,13 @@
       <family>cursive</family>
     </default>
   </alias>
+  <!-- Original PostScript base font mapping -->
+  <alias binding="same">
+    <family>Z003</family>
+    <default>
+      <family>ITC Zapf Chancery</family>
+    </default>
+  </alias>
   <!-- Font substitution rules -->
   <alias binding="same">
     <family>ITC Zapf Chancery</family>


### PR DESCRIPTION
This PR consists of several commits, that all combined should make the content of `fontconfig/` folder more concise, cleaner, and in-sync with what fontconfig upstream used for *(URW)++* fonts.

The changes include:
 * fix the `Helvetica Narrow` naming/mapping
 * adding additional substitution rule for `Standard Symbols PS`
 * adding new `urw-fallback.cong` file used for mapping/aliasing of older fonts with original PostScript fonts
 * moving fallback substitutions to `urw-fallback.conf` file
 * adding missing fallback for `Nimbus Mono` font family

Once this PR is merged, the changes to upstream can be merged as well, to finish the sync process.