### PR TITLE
appstream: fix typos and syntax errors

### DIFF
--- a/appstream/de.urwpp.C059.metainfo.xml
+++ b/appstream/de.urwpp.C059.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>C059</name>
   <summary>An alternative font family for New Century Schoolbook typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.D050000L.metainfo.xml
+++ b/appstream/de.urwpp.D050000L.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>D050000L</name>
   <summary>An alternative font for ITC Zapf Dingbats typeface</summary>
@@ -42,7 +42,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.NimbusMonoPS.metainfo.xml
+++ b/appstream/de.urwpp.NimbusMonoPS.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>Nimbus Mono PS</name>
   <summary>An alternative font family for Courier typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.NimbusRoman.metainfo.xml
+++ b/appstream/de.urwpp.NimbusRoman.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>Nimbus Roman</name>
   <summary>An alternative font family for Times New Roman typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.NimbusSans.metainfo.xml
+++ b/appstream/de.urwpp.NimbusSans.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>Nimbus Sans</name>
   <summary>An alternative font family for Helvetica typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.NimbusSansNarrow.metainfo.xml
+++ b/appstream/de.urwpp.NimbusSansNarrow.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>Nimbus Sans Narrow</name>
   <summary>An alternative font family for Helvetica Condensed typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.P052.metainfo.xml
+++ b/appstream/de.urwpp.P052.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>P052</name>
   <summary>An alternative font family for Palatino typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.StandardSymbolsPS.metainfo.xml
+++ b/appstream/de.urwpp.StandardSymbolsPS.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>Standard Symbols PS</name>
   <summary>An alternative font for Symbol typeface</summary>
@@ -42,7 +42,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.URWBookman.metainfo.xml
+++ b/appstream/de.urwpp.URWBookman.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>URW Bookman</name>
   <summary>An alternative font family for ITC Bookman typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.URWCoreFontSetLevel2.metainfo.xml
+++ b/appstream/de.urwpp.URWCoreFontSetLevel2.metainfo.xml
@@ -9,9 +9,9 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
-  <!-- NOTE: This is a meta-package to install all the Level 2 fonts --!>
+  <!-- NOTE: This is a meta-package to install all the Level 2 fonts -->
   <name>(URW)++ Core Font Set [Level 2]</name>
   <summary>An alternative font family for New Century Schoolbook typeface</summary>
   <description>
@@ -64,15 +64,15 @@
     <font>Z003 Medium Italic</font>
   </provides>
 
-  <!-- NOTE: No <suggests/> tag here, this metapackages provides all fonts ^--!>
+  <!-- NOTE: No <suggests/> tag here, this metapackages provides all fonts ^-->
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />
   </releases>
 
-  <!-- NOTE: These font locales are superset of all languages supported --!>
+  <!-- NOTE: These font locales are superset of all languages supported -->
   <languages>
     <lang>aa</lang>
     <lang>af</lang>

--- a/appstream/de.urwpp.URWGothic.metainfo.xml
+++ b/appstream/de.urwpp.URWGothic.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>URW Gothic</name>
   <summary>An alternative font family for ITC Avant Garde Gothic typeface</summary>
@@ -45,7 +45,7 @@
     <id>de.urwpp.Z003</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />

--- a/appstream/de.urwpp.Z003.metainfo.xml
+++ b/appstream/de.urwpp.Z003.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://www.urwpp.de/en/</url>
   <url type="bugtracker">https://bugs.ghostscript.com/</url>
 
-  <update_conctact>dkaspar@redhat.com</update_contact>
+  <update_contact>dkaspar@redhat.com</update_contact>
 
   <name>Z003</name>
   <summary>An alternative font for ITC Zapf Chancery typeface</summary>
@@ -42,7 +42,7 @@
     <id>de.urwpp.URWGothic</id>
   </suggests>
 
-  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream --!>
+  <!-- NOTE: Medium urgency of updates is implicitly assumed with AppStream -->
   <releases>
     <release version="20170801" date="2017-08-01" />
     <release version="20160926" date="2016-09-26" />


### PR DESCRIPTION
 * "update_conctact" should be "update_contact"
 * XML comments are closed with "-->", i.e. without an extra
   exclamation mark

Fixes https://github.com/ArtifexSoftware/urw-base35-fonts/issues/10