### PR TITLE
[fontconfig] README.md updated to suggest ordering value higher than 60

### DIFF
--- a/fontconfig/README.md
+++ b/fontconfig/README.md
@@ -9,14 +9,14 @@ fontconfig upstream and Artifex company agreed to keep these configuration files
 together with the font files themselves.
 
 In case you see some bug/error in these configuration files, feel free to report
-an issue, or (better) create a new pull-request on github.com:
+an issue, or (better) create a new pull-request on Github:
 
 https://github.com/ArtifexSoftware/urw-base35-fonts
 
 ### IMPORTANT NOTE
-Previously, the configuration for these fonts had priority/ordering value of 30.
-(The configuration was part of 30-metric-aliases.conf and 30-urw-aliases.conf in
- fontconfig upstream's default configuration files.)
+Previously, the configuration for these fonts had priority/ordering value of `30`.
+(The configuration was part of `30-metric-aliases.conf` and `30-urw-aliases.conf`
+ in fontconfig upstream's default configuration files.)
 
 Currently these files no longer contain the priority/ordering value as part of
 their name. It is preferred that each distribution using fontconfig decides on
@@ -27,5 +27,10 @@ For more info on the priority of fontconfig configuration files, visit e.g.:
 
 https://fedoraproject.org/wiki/Fontconfig_packaging_tips
 
-In case you are still not sure what priority/ordering value you should use, you
-could stick up with the previously used (default) value of 30.
+In case you are still not sure what priority/ordering value you should use,
+it is strongly recommended to use value higher than `60` (e.g. value `61` should
+be OK in most cases, because it has lower priority/ordering value than `60`).
+
+Otherwise you're risking of "hijacking" default *fontconfig* configuration
+stored in `60-latin.conf` file, and thus creating an unwanted system-wide
+change to your entire GUI.


### PR DESCRIPTION
This commit is based upon our discussion with @fabiangreffrath in issue \#13.

I still need to discuss with fontconfig upstream details about usage of `serif` for `Standard Symbol PS`, but this commit should (hopefully) prevent any other priority/ordering issues we were facing before...