### PR TITLE
AppStream: added missing </p> XML tag

### DIFF
--- a/appstream/de.urwpp.C059.metainfo.xml
+++ b/appstream/de.urwpp.C059.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.D050000L.metainfo.xml
+++ b/appstream/de.urwpp.D050000L.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.NimbusMonoPS.metainfo.xml
+++ b/appstream/de.urwpp.NimbusMonoPS.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.NimbusRoman.metainfo.xml
+++ b/appstream/de.urwpp.NimbusRoman.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.NimbusSans.metainfo.xml
+++ b/appstream/de.urwpp.NimbusSans.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.P052.metainfo.xml
+++ b/appstream/de.urwpp.P052.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.StandardSymbolsPS.metainfo.xml
+++ b/appstream/de.urwpp.StandardSymbolsPS.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.URWBookman.metainfo.xml
+++ b/appstream/de.urwpp.URWBookman.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.URWGothic.metainfo.xml
+++ b/appstream/de.urwpp.URWGothic.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>

--- a/appstream/de.urwpp.Z003.metainfo.xml
+++ b/appstream/de.urwpp.Z003.metainfo.xml
@@ -22,6 +22,7 @@
     <p>
       These 35 base fonts are provided freely by (URW++) company,
       and are mainly utilized by Ghostscript, or other applications using it.
+    </p>
   </description>
 
   <provides>


### PR DESCRIPTION
This was causing errors in AppStream parsers, causing the AppStream files not being used in software centers/updaters...