### PR TITLE
fontconfig: typo in urw-nimbus-sans.conf fixed

### DIFF
--- a/fontconfig/urw-nimbus-sans.conf
+++ b/fontconfig/urw-nimbus-sans.conf
@@ -62,14 +62,14 @@
   </alias>
 
   <alias binding="same">
-    <family>TeX Gyre Heroes</family>
+    <family>TeX Gyre Heros</family>
     <accept>
       <family>Nimbus Sans</family>
     </accept>
   </alias>
 
   <alias binding="same">
-    <family>TeX Gyre Heroes Cn</family>
+    <family>TeX Gyre Heros Cn</family>
     <accept>
       <family>Nimbus Sans Narrow</family>
     </accept>


### PR DESCRIPTION
The small typo *(Heroes -> Heros)* has been fixed.

Resolves: \#23