### PR TITLE
adding an alias to 'Century'

### DIFF
--- a/fontconfig/urw-c059.conf
+++ b/fontconfig/urw-c059.conf
@@ -41,6 +41,13 @@
   </alias>
 
   <alias binding="same">
+    <family>Century</family>
+    <accept>
+      <family>C059</family>
+    </accept>
+  </alias>
+
+  <alias binding="same">
     <family>Tex Gyre Schola</family>
     <accept>
       <family>C059</family>


### PR DESCRIPTION
attempt to address issue #33.
Details of the 'Century' font: https://docs.microsoft.com/en-us/typography/font-list/century
Not sure if it is metric equivalent, but it's a lot better than the default Deja Vu Sans that Ubuntu 20.04 chooses by default.