### PR TITLE
Remove inappropriate generic aliases for D050000L

### DIFF
--- a/fontconfig/urw-d050000l.conf
+++ b/fontconfig/urw-d050000l.conf
@@ -1,22 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-  <!-- Generic name aliasing -->
-  <alias>
-    <family>fantasy</family>
-    <prefer>
-      <family>D050000L</family>
-    </prefer>
-  </alias>
-
-  <!-- Generic name assignment -->
-  <alias>
-    <family>D050000L</family>
-    <default>
-      <family>fantasy</family>
-    </default>
-  </alias>
-
   <!-- Original PostScript base font mapping -->
   <alias binding="same">
     <family>D050000L</family>


### PR DESCRIPTION
This PR removes the generic "fantasy" font aliases for the D050000L symbol font.

The D050000L font was marked as an alias for "fantasy" but shouldn't be. As a result, if another "fantasy" font isn't installed with a higher priority, D050000L is used by some browsers (in my case Firefox, but not Chromium) when a fantasy font is requested. This results in unreadable text:

![Screenshot_2023-02-12_19-04](https://user-images.githubusercontent.com/1646628/218331906-1867fc89-1d18-4738-afcc-d4ea013813d2.png)

According to the W3C CSS1 generic font-family definitions: "Fantasy fonts are primarily decorative or expressive fonts that contain decorative or expressive representations of characters. These do not include Pi or Picture fonts which do not represent actual characters."

After removing the aliases locally and running `fc-cache -rv`, the text is readable again (although it just uses the default sans-serif font now since I apparently don't have another fantasy font installed).

(Also see my bugrep on the [Pop!_OS tracker](https://github.com/pop-os/pop/issues/2795), someone else's [Fedora report](https://bugzilla.redhat.com/show_bug.cgi?id=1909382) and an [issue in this repo](https://github.com/ArtifexSoftware/urw-base35-fonts/issues/27#issuecomment-1006432252) that provided the solution)